### PR TITLE
Fix input-derivative pairing; default to inline linear-SCC reassembly

### DIFF
--- a/src/ControlSystemsMTK.jl
+++ b/src/ControlSystemsMTK.jl
@@ -35,6 +35,23 @@ export build_quadratic_cost_matrix
 
 export get_named_sensitivity, get_named_comp_sensitivity, get_named_looptransfer
 
+"""
+Default keyword arguments forwarded to ModelingToolkit's linearization (and through it to
+`mtkcompile`) by every linearization-based function in this package (`named_ss`,
+`get_named_sensitivity` and friends, `batch_ss`, `trajectory_ss`,
+`build_quadratic_cost_matrix`). `inline_linear_sccs` makes tearing solve linear
+strongly-connected components inline (symbolically for size ≤ `analytical_linear_scc_limit`)
+rather than through numerical linear-solve calls embedded in the generated code. This is
+required for correct linearization of models with large linear SCCs (e.g. multibody
+mechanisms). Keyword arguments passed by the caller take precedence, so pass
+`reassemble_alg = ModelingToolkit.StructuralTransformations.DefaultReassembleAlgorithm()` to
+restore the ModelingToolkit default.
+"""
+const DEFAULT_LINEARIZE_KWARGS = (;
+    reassemble_alg = ModelingToolkit.StructuralTransformations.DefaultReassembleAlgorithm(;
+        inline_linear_sccs = true, analytical_linear_scc_limit = 1),
+)
+
 include("ode_system.jl")
 # include("symbolic_optimization.jl")
 

--- a/src/ode_system.jl
+++ b/src/ode_system.jl
@@ -114,8 +114,12 @@ function RobustAndOptimalControl.named_ss(
     unames = symstr.(inputs)
     if nu > 0 && size(matrices.B, 2) == 2nu
         # This indicates that input derivatives are present
-        duinds = findall(any(!iszero, eachcol(matrices.B[:, nu+1:end]))) .+ nu
-        u2du = (1:nu) .=> duinds # This maps inputs to their derivatives
+        # Derivative column nu + i is the derivative of input i (see the MTK docs for
+        # `linearize` with `allow_input_derivatives = true`), so the pairing is positional.
+        # All-zero derivative columns contribute nothing and are included for simplicity;
+        # a pairing derived from the set of nonzero columns mispairs inputs when only a
+        # subset of the derivative columns is nonzero.
+        u2du = [i => i + nu for i in 1:nu] # This maps inputs to their derivatives
         lsys = causal_simplification(matrices, u2du; descriptor, simple_infeigs, big, balance)
     else
         lsys = ss(matrices...)
@@ -154,8 +158,12 @@ function RobustAndOptimalControl.named_ss(
     unames = symstr.(inputs)
     if nu > 0 && size(matrices.B, 2) == 2nu
         # This indicates that input derivatives are present
-        duinds = findall(any(!iszero, eachcol(matrices.B[:, nu+1:end]))) .+ nu
-        u2du = (1:nu) .=> duinds # This maps inputs to their derivatives
+        # Derivative column nu + i is the derivative of input i (see the MTK docs for
+        # `linearize` with `allow_input_derivatives = true`), so the pairing is positional.
+        # All-zero derivative columns contribute nothing and are included for simplicity;
+        # a pairing derived from the set of nonzero columns mispairs inputs when only a
+        # subset of the derivative columns is nonzero.
+        u2du = [i => i + nu for i in 1:nu] # This maps inputs to their derivatives
         lsys = causal_simplification(matrices, u2du; descriptor, simple_infeigs, big, balance, verbose=false)
     else
         lsys = ss(matrices...)
@@ -307,8 +315,12 @@ function named_sensitivity_function(
     fm(x) = convert(Matrix{Float64}, x)
     if nu > 0 && size(matrices.B, 2) == 2nu
         # This indicates that input derivatives are present
-        duinds = findall(any(!iszero, eachcol(matrices.B[:, nu+1:end]))) .+ nu
-        u2du = (1:nu) .=> duinds # This maps inputs to their derivatives
+        # Derivative column nu + i is the derivative of input i (see the MTK docs for
+        # `linearize` with `allow_input_derivatives = true`), so the pairing is positional.
+        # All-zero derivative columns contribute nothing and are included for simplicity;
+        # a pairing derived from the set of nonzero columns mispairs inputs when only a
+        # subset of the derivative columns is nonzero.
+        u2du = [i => i + nu for i in 1:nu] # This maps inputs to their derivatives
         lsys = causal_simplification(matrices, u2du; descriptor, simple_infeigs, big, balance)
     else
         lsys = ss(matrices...)

--- a/src/ode_system.jl
+++ b/src/ode_system.jl
@@ -110,7 +110,7 @@ function RobustAndOptimalControl.named_ss(
             out
         end
     end
-    matrices, ssys, xpt = ModelingToolkit.linearize(sys, inputs, outputs; kwargs...)
+    matrices, ssys, xpt = ModelingToolkit.linearize(sys, inputs, outputs; DEFAULT_LINEARIZE_KWARGS..., kwargs...)
     unames = symstr.(inputs)
     if nu > 0 && size(matrices.B, 2) == 2nu
         # This indicates that input derivatives are present
@@ -301,7 +301,7 @@ function named_sensitivity_function(
         end
     end
     nu = length(inputs)
-    matrices, ssys = fun(sys, inputs, args...; kwargs...)
+    matrices, ssys = fun(sys, inputs, args...; DEFAULT_LINEARIZE_KWARGS..., kwargs...)
     symstr(x) = Symbol(x isa AnalysisPoint ? x.name : string(x))
     unames = symstr.(inputs)
     fm(x) = convert(Matrix{Float64}, x)
@@ -384,7 +384,7 @@ The second problem above, the ordering of the states, can be worked around using
 - `costs`: A vector of pairs.
 """
 function build_quadratic_cost_matrix(sys::System, inputs::AbstractVector, costs::AbstractVector{<:Pair}; kwargs...)
-    matrices, ssys, extras = ModelingToolkit.linearize(sys, inputs, first.(costs); kwargs...)
+    matrices, ssys, extras = ModelingToolkit.linearize(sys, inputs, first.(costs); DEFAULT_LINEARIZE_KWARGS..., kwargs...)
     x = ModelingToolkit.unknowns(ssys)
     y = ModelingToolkit.outputs(ssys)
     nx = length(x)
@@ -406,7 +406,7 @@ end
 function batch_linearize(sys, inputs, outputs, ops::AbstractVector{<:AbstractDict}; t = 0.0,
         allow_input_derivatives = false,
         kwargs...)
-    lin_fun, ssys = linearization_function(sys, inputs, outputs; op=ops[1], kwargs...)
+    lin_fun, ssys = linearization_function(sys, inputs, outputs; op=ops[1], DEFAULT_LINEARIZE_KWARGS..., kwargs...)
     lins_ops = map(ops) do op
         linearize(ssys, lin_fun; op, t, allow_input_derivatives)
     end
@@ -552,7 +552,7 @@ function trajectory_ss(sys, inputs, outputs, sol; t = _max_100(sol.t), allow_inp
         ops = reduce(vcat, opsv)
         t = repeat(t, inner = length(ops) ÷ length(t))
     end
-    lin_fun, ssys = linearization_function(sys, inputs, outputs; op=ops[1], kwargs...)#, initialization_abstol=1e-1, initialization_reltol=1e-1, kwargs...) # initializealg=ModelingToolkit.SciMLBase.NoInit()
+    lin_fun, ssys = linearization_function(sys, inputs, outputs; op=ops[1], DEFAULT_LINEARIZE_KWARGS..., kwargs...)#, initialization_abstol=1e-1, initialization_reltol=1e-1, kwargs...) # initializealg=ModelingToolkit.SciMLBase.NoInit()
     # Main.lin_fun = lin_fun
     # Main.op1 = ops[1]
     # Main.ops = ops 


### PR DESCRIPTION
Two changes to the linearization pipeline, found while linearizing a planar two-joint robot (a model whose large linear SCCs take the numerical LinearSolve-based path under the default reassembly).

## Fix: input-derivative column pairing in `causal_simplification` call sites

`ModelingToolkit.linearize` with `allow_input_derivatives = true` returns `B` with `2nu` columns, where column `nu + i` is the derivative of input `i`. The pairing passed to `causal_simplification` was derived by broadcasting `1:nu` against the set of *nonzero* derivative columns:

```julia
duinds = findall(any(!iszero, eachcol(matrices.B[:, nu+1:end]))) .+ nu
u2du = (1:nu) .=> duinds
```

When exactly one derivative column is nonzero this silently broadcasts to `[1 => k, 2 => k, ...]`, pairing **every** input to the same derivative channel; other partial subsets throw a `DimensionMismatch`. The result is a wrong reduced system whenever inputs enter retained algebraic equations. On the robot, the input complementary sensitivity collapsed to a rank-1 projector (`Ti(0) ≈ [1 1; 0 0]` instead of `I`), i.e. the loop transfer's input columns came out identical.

The pairing is now positional over all inputs, `[i => i + nu for i in 1:nu]`; all-zero derivative columns contribute nothing (and filtering them out is not an option, since `causal_simplification` infers the input count from the number of pairs).

Verified on a minimal 5-equation model with a 3×3 linear SCC and two inputs: the numerically-reassembled linearization now matches the symbolically-inlined one to a relative error of 6e-16 (previously ~100% error); the robot's input complementary sensitivity matches to 8e-13 across frequency.

## Default: inline linear-SCC reassembly for all linearizations

`DEFAULT_LINEARIZE_KWARGS = (; reassemble_alg = DefaultReassembleAlgorithm(; inline_linear_sccs = true, analytical_linear_scc_limit = 1))` is now forwarded by every linearization-based function (`named_ss`, `get_named_sensitivity`/`get_named_comp_sensitivity`/`get_named_looptransfer`, `batch_ss`/`batch_linearize`, `trajectory_ss`, `build_quadratic_cost_matrix`). Caller-supplied keyword arguments take precedence, so the ModelingToolkit default remains reachable.

With the pairing fix above, both reassembly paths produce correct linearizations; the inline default is kept because it avoids the input-derivative-augmented form entirely (no spurious marginal modes, better conditioned realizations) on models with linear SCCs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
