### PR TITLE
Add DataInterpolations as test-only dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,10 +25,11 @@ julia = "1.10"
 
 [extras]
 ControlSystems = "a6e380b2-a6ca-5380-bf3e-84a91bcd477e"
+DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
 GenericLinearAlgebra = "14197337-ba66-59df-a3e3-ca00e7dcff7a"
 OrdinaryDiffEqNonlinearSolve = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
 OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "ControlSystems", "GenericLinearAlgebra", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqNonlinearSolve"]
+test = ["Test", "ControlSystems", "DataInterpolations", "GenericLinearAlgebra", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqNonlinearSolve"]


### PR DESCRIPTION
DataInterpolations was dropped from `[deps]` in 3bbba87 since it is unused in `src/`, but the test suite still loads it: `test/test_batchlin.jl` uses `LinearInterpolation` as the `interpolator` for `GainScheduledStateSpace`. This adds it back under `[extras]` and the `test` target only.

Verified locally: `Pkg.test()` passes (37 pass, 1 broken) with the test environment resolving DataInterpolations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)