### PR TITLE
Fix named_ss(sys, linfun, outputs) on ModelingToolkit 11.36

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ControlSystemsMTK"
 uuid = "687d7614-c7e5-45fc-bfc3-9ee385575c88"
 authors = ["Fredrik Bagge Carlson"]
-version = "2.8.0"
+version = "2.8.1"
 
 [deps]
 ControlSystemsBase = "aaaaaaaa-a6ca-5380-bf3e-84a91bcd477e"

--- a/src/ode_system.jl
+++ b/src/ode_system.jl
@@ -153,7 +153,10 @@ function RobustAndOptimalControl.named_ss(
 )
     ssys = sys
     matrices, xpt = ModelingToolkit.linearize(sys, linfun; kwargs...)
-    inputs = linfun.inputs
+    # ModelingToolkit 11.36 removed the `inputs` field from LinearizationFunction;
+    # the input variables are recovered from the simplified system instead, which
+    # is what the operating-point extraction below already relies on.
+    inputs = ModelingToolkit.inputs(ssys)
     nu = length(inputs)
     unames = symstr.(inputs)
     if nu > 0 && size(matrices.B, 2) == 2nu

--- a/test/test_ODESystem.jl
+++ b/test/test_ODESystem.jl
@@ -54,6 +54,12 @@ P02_named = named_ss(P, [input.u], [output.u]; op)
 P02 = ss(P02_named)
 @test P02 == P0 # verify that we get back what we started with
 
+# named_ss from a precompiled LinearizationFunction (hot path)
+lin_fun, sslin = ModelingToolkit.linearization_function(P, [input.u], [output.u]; op)
+P02_linfun = named_ss(sslin, lin_fun, [output.u]; op)
+@test P02_linfun.u == [Symbol("input₊u(t)")]
+@test ss(P02_linfun) == P0
+
 # same for controller
 x = unknowns(C)
 @nonamespace C02 = named_ss(C, [C.input], [C.output]; op)


### PR DESCRIPTION
MTK 11.36 removed the `inputs` field from `LinearizationFunction` (replaced by `inputs_getter`/`num_inputs`), so the `named_ss(sys, linfun::LinearizationFunction, outputs)` method throws a `FieldError` on any use (this is the hot path used by DyadControlSystems' `get_tf`).

Since v2.8.0 already requires `ModelingToolkit = "11.36"`, the released version cannot work with any resolvable MTK, hence the patch bump to 2.8.1.

Fix: recover the input variables from the simplified system via `ModelingToolkit.inputs(ssys)`, which the operating-point extraction a few lines below already relies on (same order assumption as before).

Added a regression test exercising `linearization_function` → `named_ss(ssys, lin_fun, outputs)`. Verified against MTK 11.36.0: the new test passes, and DyadControlSystems' `test_get_tf.jl` (which hits this path) goes from FieldError to fully passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QR4FuuvxZU9a3UrTJjg5X